### PR TITLE
Fix DB integration for claim creation and storage types

### DIFF
--- a/server/mock-storage.ts
+++ b/server/mock-storage.ts
@@ -122,9 +122,19 @@ export class MockStorage implements IStorage {
     const newClaim: Claim = {
       id: `claim-${Date.now()}`,
       created_at: new Date(),
-      ...claim,
+      placa: claim.placa,
+      cpf_segurado: claim.cpf_segurado,
+      data_evento: claim.data_evento,
+      local_evento_cidade: claim.local_evento_cidade,
+      local_evento_uf: claim.local_evento_uf,
+      tipo_sinistro: claim.tipo_sinistro,
+      status: claim.status || "aberto",
       franquia_prevista: claim.franquia_prevista?.toString() || "0",
-      prob_pt: claim.prob_pt?.toString() || null
+      prob_pt: claim.prob_pt?.toString() || null,
+      estimativa_id: claim.estimativa_id ?? null,
+      oficina_id: claim.oficina_id ?? null,
+      terceiro_token: claim.terceiro_token ?? null,
+      resumo: claim.resumo ?? null,
     };
     mockClaims.push(newClaim);
     return newClaim;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -139,6 +139,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Create new claim (nova API)
+  app.post("/api/claims", async (req, res) => {
+    try {
+      const validated = insertClaimSchema.parse(req.body);
+      const storage = await getStorage();
+      const claim = await storage.createClaim(validated);
+      res.status(201).json(claim);
+    } catch (error) {
+      console.error("Error creating claim:", error);
+      res.status(500).json({ message: "Erro ao criar claim" });
+    }
+  });
+
   // Create new sinistro
   app.post("/api/sinistros", async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -59,7 +59,8 @@ const createStorageInstance = async (): Promise<IStorage> => {
     console.log("🔗 Connected to:", databaseUrl.replace(/:\/\/.*@/, '://***@'));
     return new PostgresStorage();
   } catch (error) {
-    console.log("⚠️  Database connection failed - falling back to mock storage:", error.message);
+    const message = error instanceof Error ? error.message : String(error);
+    console.log("⚠️  Database connection failed - falling back to mock storage:", message);
     return new MockStorage();
   }
 };
@@ -298,7 +299,7 @@ export class PostgresStorage implements IStorage {
         .insert(sinistros)
         .values({
           ...sinistro,
-          prazo_limite: prazoLimite.toISOString().split('T')[0]
+          prazo_limite: prazoLimite
         })
         .returning();
       


### PR DESCRIPTION
## Summary
- add POST /api/claims route to create new claims for NovoSinistro flow
- handle DB connection errors and prazo_limite type in storage
- ensure mock storage creates complete Claim objects with default status and nullable IDs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a7aec37d0883219e223e09ad746cec